### PR TITLE
feat: Update cosmovisor.service.j2

### DIFF
--- a/roles/services/templates/cosmovisor.service.j2
+++ b/roles/services/templates/cosmovisor.service.j2
@@ -8,6 +8,7 @@ Environment="DAEMON_HOME={{ chain_home }}"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="DAEMON_LOG_BUFFER_SIZE=512"
+Environment="UNSAFE_SKIP_BACKUP=true"
 User={{node_user}}
 ExecStart={{ cosmovisor_bin }} run start --home {{ chain_home }}
 StandardOutput=append:/var/log/cosmovisor.log


### PR DESCRIPTION
The commit adds the Environment variable needed to skip backups during upgrades, This is heavily benefitial in my mind as We would rather use a smaller more recent public snapshot if the node where to crash so the backups take up unneeded space.